### PR TITLE
xTB Calculator

### DIFF
--- a/ipsuite/calculators/__init__.py
+++ b/ipsuite/calculators/__init__.py
@@ -1,7 +1,7 @@
 from ipsuite.calculators.ase_geoopt import ASEGeoOpt
 from ipsuite.calculators.ase_md import ASEMD, FixedSphereASEMD
 from ipsuite.calculators.cp2k import CP2KSinglePoint, CP2KYaml
-from ipsuite.calculators.xtb import xTBCalc
+from ipsuite.calculators.xtb import xTBSinglePoint
 
 __all__ = [
     "CP2KSinglePoint",
@@ -9,5 +9,5 @@ __all__ = [
     "ASEGeoOpt",
     "ASEMD",
     "FixedSphereASEMD",
-    "xTBCalc",
+    "xTBSinglePoint",
 ]

--- a/ipsuite/calculators/__init__.py
+++ b/ipsuite/calculators/__init__.py
@@ -1,6 +1,7 @@
 from ipsuite.calculators.ase_geoopt import ASEGeoOpt
 from ipsuite.calculators.ase_md import ASEMD, FixedSphereASEMD
 from ipsuite.calculators.cp2k import CP2KSinglePoint, CP2KYaml
+from ipsuite.calculators.xtb import xTBCalc
 
 __all__ = [
     "CP2KSinglePoint",
@@ -8,4 +9,5 @@ __all__ = [
     "ASEGeoOpt",
     "ASEMD",
     "FixedSphereASEMD",
+    "xTBCalc",
 ]

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -11,7 +11,7 @@ class xTBCalc(zntrack.Node):
     Attributes
     ----------
     method: str
-        xTB method to be used. 
+        xTB method to be used. Only "GFN1-xTB" supports PBC.
     """
     method: str =  zntrack.zn.params("GFN1-xTB")
 

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -21,7 +21,6 @@ class xTBSinglePoint(base.ProcessAtoms):
 
     def run(self):
         self.atoms = self.get_data()
-        print(self.atoms)
 
         calculator = self.calc
 

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -1,0 +1,29 @@
+import logging
+
+import zntrack 
+
+log = logging.getLogger(__name__)
+
+
+class xTBCalc(zntrack.Node):
+    """Node for obtaining xTB calculators.
+
+    Attributes
+    ----------
+    method: str
+        xTB method to be used. 
+    """
+    method: str =  zntrack.zn.params("GFN1-xTB")
+
+    @property
+    def calc(self):
+        """Get an xtb ase calculator."""
+        try:
+            from xtb.ase.calculator import XTB
+        except ImportError:
+            log.warning(
+                "No xtb-python installation found. install via `conda install xtb-python`"
+            )
+
+        xtb = XTB(method=self.method)
+        return xtb

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -1,6 +1,6 @@
 import logging
 
-import zntrack 
+import zntrack
 
 log = logging.getLogger(__name__)
 
@@ -13,7 +13,8 @@ class xTBCalc(zntrack.Node):
     method: str
         xTB method to be used. Only "GFN1-xTB" supports PBC.
     """
-    method: str =  zntrack.zn.params("GFN1-xTB")
+
+    method: str = zntrack.zn.params("GFN1-xTB")
 
     @property
     def calc(self):

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -1,12 +1,15 @@
 import logging
 
+import tqdm
 import zntrack
+
+from ipsuite import base
 
 log = logging.getLogger(__name__)
 
 
-class xTBCalc(zntrack.Node):
-    """Node for obtaining xTB calculators.
+class xTBSinglePoint(base.ProcessAtoms):
+    """Node for labeling date with xTB and obtaining ASE calculators.
 
     Attributes
     ----------
@@ -15,6 +18,16 @@ class xTBCalc(zntrack.Node):
     """
 
     method: str = zntrack.zn.params("GFN1-xTB")
+
+    def run(self):
+        self.atoms = self.get_data()
+        print(self.atoms)
+
+        calculator = self.calc
+
+        for atom in tqdm.tqdm(self.atoms):
+            atom.calc = calculator
+            atom.get_potential_energy()
 
     @property
     def calc(self):


### PR DESCRIPTION
This PR adds a simple Node which returns an ASE calculator from `xtb-python`.
Useful for testing and to run MDs to sample from.
That package needs to be installed via conda, which is why the import is done in the Node itself.