### PR TITLE
Barycenter Mapping

### DIFF
--- a/ipsuite/__init__.py
+++ b/ipsuite/__init__.py
@@ -8,6 +8,7 @@ from ipsuite import (
     configuration_comparison,
     configuration_selection,
     fields,
+    geometry,
     models,
     utils,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "analysis",
     "fields",
     "calculators",
+    "geometry",
 ]
 
 __version__ = importlib.metadata.version(__name__)

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -415,7 +415,7 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
     """
 
     model: models.MLModel = zntrack.zn.deps()
-    mapping: base.Mapping = zntrack.zn.nodes()
+    mapping: base.Mapping = zntrack.zn.nodes(None)
 
     logspace: bool = zntrack.zn.params(False)
     stop: float = zntrack.zn.params(2.0)
@@ -454,10 +454,10 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
 
         for scale in tqdm.tqdm(scale_space, ncols=70):
             if self.mapping is not None:
-                atoms, molecules = self.mapping.forward_map(atoms)
+                atoms, molecules = self.mapping.forward_mapping(atoms)
             atoms.set_cell(cell=cell * scale, scale_atoms=True)
             if self.mapping is not None:
-                atoms = self.mapping.backward_map(atoms, molecules)
+                atoms = self.mapping.backward_mapping(atoms, molecules)
             energies.append(atoms.get_potential_energy())
             self.atoms.append(atoms.copy())
 

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -431,7 +431,7 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
     def post_init(self):
         self.data = utils.helpers.get_deps_if_node(self.data, "atoms")
         if self.start is None:
-            self.start = 0.0 if self.logspace else 1.0
+            self.start = 1.0
 
     def run(self):
         scale_space = (

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -434,9 +434,7 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
             self.start = 1.0
 
     def run(self):
-        scale_space = (
-            np.linspace(start=self.start, stop=self.stop, num=self.num)
-        )
+        scale_space = np.linspace(start=self.start, stop=self.stop, num=self.num)
 
         atoms = self.get_data()
         cell = atoms.copy().cell

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -449,8 +449,11 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
             if self.mapping is not None:
                 atoms, molecules = self.mapping.forward_mapping(atoms)
             atoms.set_cell(cell=cell * scale, scale_atoms=True)
+
             if self.mapping is not None:
                 atoms = self.mapping.backward_mapping(atoms, molecules)
+                # New atoms object, does not have the calculator.
+                atoms.calc = self.model.calc
             energies.append(atoms.get_potential_energy())
             self.atoms.append(atoms.copy())
 

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -417,9 +417,7 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
     model: models.MLModel = zntrack.zn.deps()
     mapping: base.Mapping = zntrack.zn.nodes(None)
 
-    logspace: bool = zntrack.zn.params(False)
     stop: float = zntrack.zn.params(2.0)
-    factor: float = zntrack.zn.params(1.0)
     num: int = zntrack.zn.params(100)
     start: float = zntrack.zn.params(None)
 
@@ -436,14 +434,9 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
             self.start = 0.0 if self.logspace else 1.0
 
     def run(self):
-        if self.logspace:
-            scale_space = (
-                np.logspace(start=self.start, stop=self.stop, num=self.num) * self.factor
-            )
-        else:
-            scale_space = (
-                np.linspace(start=self.start, stop=self.stop, num=self.num) * self.factor
-            )
+        scale_space = (
+            np.linspace(start=self.start, stop=self.stop, num=self.num)
+        )
 
         atoms = self.get_data()
         cell = atoms.copy().cell

--- a/ipsuite/analysis/model.py
+++ b/ipsuite/analysis/model.py
@@ -415,6 +415,7 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
     """
 
     model: models.MLModel = zntrack.zn.deps()
+    mapping: base.Mapping = zntrack.zn.nodes()
 
     logspace: bool = zntrack.zn.params(False)
     stop: float = zntrack.zn.params(2.0)
@@ -452,7 +453,11 @@ class BoxScaleAnalysis(base.ProcessSingleAtom):
         self.atoms = []
 
         for scale in tqdm.tqdm(scale_space, ncols=70):
+            if self.mapping is not None:
+                atoms, molecules = self.mapping.forward_map(atoms)
             atoms.set_cell(cell=cell * scale, scale_atoms=True)
+            if self.mapping is not None:
+                atoms = self.mapping.backward_map(atoms, molecules)
             energies.append(atoms.get_potential_energy())
             self.atoms.append(atoms.copy())
 

--- a/ipsuite/base/__init__.py
+++ b/ipsuite/base/__init__.py
@@ -4,6 +4,7 @@ from ipsuite.base import protocol
 from ipsuite.base.base import (
     AnalyseAtoms,
     AnalyseProcessAtoms,
+    Mapping,
     ProcessAtoms,
     ProcessSingleAtom,
 )
@@ -14,4 +15,5 @@ __all__ = [
     "AnalyseAtoms",
     "AnalyseProcessAtoms",
     "protocol",
+    "Mapping",
 ]

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -123,11 +123,22 @@ class AnalyseProcessAtoms(zntrack.Node):
 
 
 class Mapping(ProcessSingleAtom):
+    """Base class for transforming ASE `Atoms`.
+    `Mapping` nodes can be used in a more functional manner when initialized
+    with `data=None` outside the project graph.
+    In that case, one can use the mapping methods but the Node itself does not store
+    the transformed configurations.
+    """
+
     def run(self):
         self.atoms, self.molecules = self.forward_mapping(self.data)
 
-    def forward_mapping(self, atoms):
+    def forward_mapping(
+        self, atoms: ase.Atoms
+    ) -> typing.Tuple[ase.Atoms, list[ase.Atoms]]:
         raise NotImplementedError
 
-    def backward_mapping(self, cg_atoms, molecules):
+    def backward_mapping(
+        self, cg_atoms: ase.Atoms, molecules: list[ase.Atoms]
+    ) -> list[ase.Atoms]:
         raise NotImplementedError

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -120,3 +120,11 @@ class AnalyseProcessAtoms(zntrack.Node):
     def get_data(self) -> typing.Tuple[list[ase.Atoms], list[ase.Atoms]]:
         self.data.update_data()  # otherwise, data might not be available
         return self.data.data, self.data.atoms
+
+
+class Mapping(zntrack.Node):
+    def forward_mapping(self, atoms):
+        raise NotImplementedError
+
+    def backward_mapping(self, cg_atoms, molecules):
+        raise NotImplementedError

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -123,7 +123,6 @@ class AnalyseProcessAtoms(zntrack.Node):
 
 
 class Mapping(ProcessSingleAtom):
-
     def run(self):
         self.atoms, self.molecules = self.forward_mapping(self.data)
 

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -122,7 +122,11 @@ class AnalyseProcessAtoms(zntrack.Node):
         return self.data.data, self.data.atoms
 
 
-class Mapping(zntrack.Node):
+class Mapping(ProcessSingleAtom):
+
+    def run(self):
+        self.atoms, self.molecules = self.forward_mapping(self.data)
+
     def forward_mapping(self, atoms):
         raise NotImplementedError
 

--- a/ipsuite/geometry/__init__.py
+++ b/ipsuite/geometry/__init__.py
@@ -1,0 +1,3 @@
+from ipsuite.geometry.mapping import BarycenterMapping
+
+__all__ = ["BarycenterMapping"]

--- a/ipsuite/geometry/barycenter_coarse_grain.py
+++ b/ipsuite/geometry/barycenter_coarse_grain.py
@@ -1,0 +1,31 @@
+import numpy as np
+from ase import Atoms
+
+
+def coarse_grain_to_barycenter(molecules):
+    coms = np.zeros(shape=(len(molecules), 3))
+    for ii, mol in enumerate(molecules):
+        com = np.mean(mol.positions, axis=0)
+        coms[ii] = com
+    atomic_numbers = f"H{len(coms)}"
+
+    cg_positions = np.stack(coms, axis=0)
+    cg_atoms = Atoms(atomic_numbers, positions=cg_positions, cell=molecules[0].cell)
+
+    return cg_atoms
+
+
+def barycenter_backmapping(cg_atoms, molecules):
+    coms = cg_atoms.positions
+    shifted_molecules = []
+    for ii, mol in enumerate(molecules):
+        shifted_mol = mol.copy()
+        mol_com = np.mean(mol.positions, axis=0)
+        shifted_mol.positions += coms[ii] - mol_com
+        shifted_molecules.append(shifted_mol)
+
+    atoms = shifted_molecules[0]
+    for i in range(1, len(shifted_molecules)):
+        atoms += shifted_molecules[i]
+    atoms.cell = cg_atoms.cell
+    return atoms

--- a/ipsuite/geometry/graphs.py
+++ b/ipsuite/geometry/graphs.py
@@ -1,0 +1,24 @@
+import networkx as nx
+import numpy as np
+from ase.neighborlist import build_neighbor_list
+
+
+def atoms_to_graph(atoms):
+    # This can be optimized by reusing the NL!
+    nl = build_neighbor_list(atoms, self_interaction=False)
+    cm = nl.get_connectivity_matrix(sparse=False)
+    G = nx.from_numpy_array(cm)
+    return G
+
+
+def identify_molecules(atoms):
+    G = atoms_to_graph(atoms)
+    components = nx.connected_components(G)
+    c_list = [np.array(list(c)) for c in components]
+    return c_list
+
+
+def edges_from_atoms(atoms):
+    G = atoms_to_graph(atoms)
+    edges = np.array(G.edges)
+    return edges

--- a/ipsuite/geometry/graphs.py
+++ b/ipsuite/geometry/graphs.py
@@ -1,9 +1,13 @@
+import ase
 import networkx as nx
 import numpy as np
 from ase.neighborlist import build_neighbor_list
 
 
-def atoms_to_graph(atoms):
+def atoms_to_graph(atoms: ase.Atoms) -> nx.Graph:
+    """Converts ASE Atoms into a Graph based on their
+    bond connectivity.
+    """
     # This can be optimized by reusing the NL!
     nl = build_neighbor_list(atoms, self_interaction=False)
     cm = nl.get_connectivity_matrix(sparse=False)
@@ -11,14 +15,16 @@ def atoms_to_graph(atoms):
     return G
 
 
-def identify_molecules(atoms):
+def identify_molecules(atoms: ase.Atoms) -> list[np.ndarray]:
+    """Identifies molecules in a structure based on the connected subgraphs."""
     G = atoms_to_graph(atoms)
     components = nx.connected_components(G)
     c_list = [np.array(list(c)) for c in components]
     return c_list
 
 
-def edges_from_atoms(atoms):
+def edges_from_atoms(atoms: ase.Atoms) -> np.ndarray:
+    """Returns the graph edges of a molecular graph."""
     G = atoms_to_graph(atoms)
     edges = np.array(G.edges)
     return edges

--- a/ipsuite/geometry/mapping.py
+++ b/ipsuite/geometry/mapping.py
@@ -1,0 +1,16 @@
+"""Molecule Mapping using networkx"""
+
+from ipsuite import base
+from ipsuite.geometry import barycenter_coarse_grain, graphs, unwrap
+
+
+class BarycenterMapping(base.Mapping):
+    def forward_mapping(self, atoms):
+        components = graphs.identify_molecules(atoms)
+        molecules = unwrap.unwrap_system(atoms, components)
+        cg_atoms = barycenter_coarse_grain.coarse_grain_to_barycenter(molecules)
+        return cg_atoms, molecules
+
+    def backward_mapping(self, cg_atoms, molecules):
+        atoms = barycenter_coarse_grain.barycenter_backmapping(cg_atoms, molecules)
+        return atoms

--- a/ipsuite/geometry/mapping.py
+++ b/ipsuite/geometry/mapping.py
@@ -1,16 +1,24 @@
 """Molecule Mapping using networkx"""
+import typing
+
+import ase
 
 from ipsuite import base
 from ipsuite.geometry import barycenter_coarse_grain, graphs, unwrap
 
 
 class BarycenterMapping(base.Mapping):
-    def forward_mapping(self, atoms):
+    """Node that "coarse grains" each molecule in a configuration into its center of mass.
+    Useful for operations affecting intermolecular distance,
+    but not intramolecular distances.
+    """
+
+    def forward_mapping(self, atoms) -> typing.Tuple[ase.Atoms, list[ase.Atoms]]:
         components = graphs.identify_molecules(atoms)
         molecules = unwrap.unwrap_system(atoms, components)
         cg_atoms = barycenter_coarse_grain.coarse_grain_to_barycenter(molecules)
         return cg_atoms, molecules
 
-    def backward_mapping(self, cg_atoms, molecules):
+    def backward_mapping(self, cg_atoms, molecules) -> list[ase.Atoms]:
         atoms = barycenter_coarse_grain.barycenter_backmapping(cg_atoms, molecules)
         return atoms

--- a/ipsuite/geometry/unwrap.py
+++ b/ipsuite/geometry/unwrap.py
@@ -1,3 +1,4 @@
+import ase
 import numpy as np
 
 from ipsuite.geometry.graphs import edges_from_atoms
@@ -44,7 +45,14 @@ def unwrap(atoms, edges, idx):
         unwrap(atoms, filtered_edges, next_idx)
 
 
-def unwrap_system(atoms, components):
+def unwrap_system(atoms: ase.Atoms, components: list[np.ndarray]) -> list[ase.Atom]:
+    """Molecules in a system which extend across periodic bounaries are mapped such that
+    they are connected but dangle out of the cell.
+    Mapping to the side where the fragment of molecule is closest
+    to the cell center is preferred.
+    Can be reversed by joining the returned molecules
+    and calling the `atoms.wrap()` method.
+    """
     molecules = []
     for component in components:
         mol = atoms[component].copy()

--- a/ipsuite/geometry/unwrap.py
+++ b/ipsuite/geometry/unwrap.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from ipsuite.geometry.graphs import edges_from_atoms
+
+
+def closest_atom_to_center(atoms):
+    closest_atom = np.argmin(
+        np.linalg.norm(atoms.positions - np.diag(atoms.cell) / 2, ord=2, axis=1)
+    )
+    return closest_atom
+
+
+def sort_atomic_edges(edges, idx):
+    idxs = np.nonzero(np.any(edges == idx, axis=1))[0]
+    current_edges = edges[idxs]
+
+    unsorted = current_edges[:, 1] == idx
+    unsorted = np.nonzero(unsorted)[0]
+    for idx in unsorted:
+        current_edges[idx][[0, 1]] = current_edges[idx][[1, 0]]
+    return current_edges
+
+
+def displace_neighbors(mol, edges):
+    for edge in edges:
+        dist = mol.get_distance(edge[0], edge[1], vector=True)
+        pdist = mol.get_distance(edge[0], edge[1], True, vector=True)
+
+        displacement = dist - pdist
+        mol.positions[edge[1]] -= displacement
+
+
+def unwrap(atoms, edges, idx):
+    # TODO this should probably be width first, not depth first
+    current_edges = sort_atomic_edges(edges, idx)
+    displace_neighbors(atoms, current_edges)
+
+    next_idxs = current_edges[:, 1]
+
+    mask = np.all(edges != idx, axis=1)
+    filtered_edges = edges[mask]
+
+    for next_idx in next_idxs:
+        unwrap(atoms, filtered_edges, next_idx)
+
+
+def unwrap_system(atoms, components):
+    molecules = []
+    for component in components:
+        mol = atoms[component].copy()
+        edges = edges_from_atoms(mol)
+        closest_atom = closest_atom_to_center(atoms)
+        unwrap(mol, edges, idx=closest_atom)
+        molecules.append(mol)
+
+    return molecules


### PR DESCRIPTION
> Moved https://github.com/zincware/IPSuite/pull/9 from fork to branch

I have implemented some functionality that lets IPS identify molecules in an `Atoms` object (based on ASE's natural cutoffs) as well as a Mapping Node which "coarse grains" those molecules to their individual centers of mass. This allows the boxscaleanalysis to be performed without stretching bonds.

Some possible improvements would be:
- more flexible bond cutoff distances (ASE's are quite long iirc)
- breadth first instead of depth first tree traversal for the unwrapping code. Currently there are some redundant operations but the result is still correct.
-  Reuse the neighborlist for constructing the connectivity matrix. This could be useful if we decide that we want to use the Node to map entire datasets, not just individual structures. 

Currently I've only tested the standalone node and opened the PR to get some feedback. I will test it with the boxscaleanalysis after I received the okay for the design.

code snippet from my test:

```python
from ipsuite import geometry
from ase.io import read
from ase.visualize import view

atoms = read("bmim.extxyz")

mapping = geometry.BarycenterMapping()

cg_atoms, molecules = mapping.forward_mapping(atoms)
cell = cg_atoms.cell
small_cell = cell * 2

cg_atoms.set_cell(small_cell, scale_atoms=True)
view(cg_atoms)

shifted_atoms = mapping.backward_mapping(cg_atoms, molecules)
view(shifted_atoms)
```