### PR TITLE
use DVC Filesystem to open files

### DIFF
--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -52,8 +52,12 @@ class ProcessAtoms(IPSNode):
         if self.data is not None:
             return self.data
         elif self.data_file is not None:
-            with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
-                return list(ase.io.iread(f))
+            try:
+                with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
+                    return list(ase.io.iread(f))
+            except FileNotFoundError:
+                # File can not be opened with DVCFileSystem, try normal open
+                return list(ase.io.iread(self.data_file))
         else:
             raise ValueError("No data given.")
 
@@ -103,8 +107,12 @@ class ProcessSingleAtom(IPSNode):
             else:
                 atoms = self.data.copy()
         elif self.data_file is not None:
-            with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
-                atoms = list(ase.io.iread(f))[self.data_id]
+            try:
+                with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
+                    atoms = list(ase.io.iread(f))[self.data_id]
+            except FileNotFoundError:
+                # File can not be opened with DVCFileSystem, try normal open
+                atoms = list(ase.io.iread(self.data_file))[self.data_id]
         else:
             raise ValueError("No data given.")
         return atoms

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -1,5 +1,6 @@
 import abc
 import collections.abc
+import pathlib
 import typing
 
 import ase
@@ -51,7 +52,8 @@ class ProcessAtoms(IPSNode):
         if self.data is not None:
             return self.data
         elif self.data_file is not None:
-            return list(ase.io.iread(self.data_file))
+            with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
+                return list(ase.io.iread(f))
         else:
             raise ValueError("No data given.")
 
@@ -101,7 +103,8 @@ class ProcessSingleAtom(IPSNode):
             else:
                 atoms = self.data.copy()
         elif self.data_file is not None:
-            atoms = list(ase.io.iread(self.data_file))[self.data_id]
+            with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
+                atoms = list(ase.io.iread(f))[self.data_id]
         else:
             raise ValueError("No data given.")
         return atoms

--- a/ipsuite/calculators/apax_jax_md.py
+++ b/ipsuite/calculators/apax_jax_md.py
@@ -91,6 +91,6 @@ class ApaxJaxMD(ProcessSingleAtom):
 
     @functools.cached_property
     def atoms(self) -> typing.List[ase.Atoms]:
-        return list(
-            ase.io.iread(self.sim_dir / "md.traj")
-        )  # filename should be changeable
+        # filename should be changeable
+        with self.state.fs.open((self.sim_dir / "md.traj").as_posix()) as f:
+            return list(ase.io.iread(f))

--- a/ipsuite/calculators/ase_geoopt.py
+++ b/ipsuite/calculators/ase_geoopt.py
@@ -43,4 +43,5 @@ class ASEGeoOpt(base.ProcessSingleAtom):
 
     @property
     def atoms(self):
-        return list(ase.io.iread(self.traj.as_posix()))
+        with self.state.fs.open(self.traj.as_posix()) as f:
+            return list(ase.io.iread(f))

--- a/tests/integration/test_configuration_selection.py
+++ b/tests/integration/test_configuration_selection.py
@@ -1,5 +1,4 @@
 import random
-import subprocess
 import typing
 
 import ase

--- a/tests/integration/test_configuration_selection.py
+++ b/tests/integration/test_configuration_selection.py
@@ -1,4 +1,5 @@
 import random
+import subprocess
 import typing
 
 import ase


### PR DESCRIPTION
To be able to load data via `zntrack.from_rev` or `node.from_rev` respectively opening a file should be done through the DVC Filesystem

# TODOs
- this is not the case e.g. for the apax model node (moved to https://github.com/zincware/ZnTrack/issues/637)