### PR TITLE
Geoopt h5

### DIFF
--- a/ipsuite/analysis/model/dynamics_checks.py
+++ b/ipsuite/analysis/model/dynamics_checks.py
@@ -147,7 +147,7 @@ class ThresholdCheck(base.CheckBase):
     max_std: float = zntrack.zn.params(None)
     window_size: int = zntrack.zn.params(500)
     max_value: float = zntrack.zn.params(None)
-    minimum_window_size: int = zntrack.zn.params(50)
+    minimum_window_size: int = zntrack.zn.params(1)
     larger_only: bool = zntrack.zn.params(False)
 
     def _post_init_(self):
@@ -178,7 +178,7 @@ class ThresholdCheck(base.CheckBase):
         if len(self.values) < self.minimum_window_size:
             return False
 
-        if self.max_value is not None and value > self.max_value:
+        if self.max_value is not None and np.max(value) > self.max_value:
             return True
 
         if self.max_std is not None and distance > self.max_std * std:

--- a/ipsuite/calculators/ase_geoopt.py
+++ b/ipsuite/calculators/ase_geoopt.py
@@ -77,8 +77,7 @@ class ASEGeoOpt(base.ProcessSingleAtom):
                     )
 
             if any(stop):
-                for checker in self.checker_list:
-                    print(checker.status)
+                dyn.log()
                 break
 
         db.add(

--- a/ipsuite/calculators/ase_geoopt.py
+++ b/ipsuite/calculators/ase_geoopt.py
@@ -1,11 +1,14 @@
 import logging
 import pathlib
+import typing
 
 import ase.io
 import ase.optimize
+import znh5md
 import zntrack
 
 from ipsuite import base
+from ipsuite.utils.ase_sim import freeze_copy_atoms
 
 log = logging.getLogger(__name__)
 
@@ -22,26 +25,75 @@ class ASEGeoOpt(base.ProcessSingleAtom):
     model = zntrack.zn.deps()
     model_outs = zntrack.dvc.outs(zntrack.nwd / "model_outs")
     optimizer: str = zntrack.zn.params("FIRE")
-    traj: pathlib.Path = zntrack.dvc.outs(zntrack.nwd / "optim.traj")
+    checker_list: list = zntrack.zn.nodes(None)
 
     repeat: list = zntrack.zn.params([1, 1, 1])
     run_kwargs: dict = zntrack.zn.params({"fmax": 0.05})
     init_kwargs: dict = zntrack.zn.params({})
+    dump_rate = zntrack.zn.params(1000)
+
+    traj_file: pathlib.Path = zntrack.dvc.outs(zntrack.nwd / "trajectory.h5")
 
     def run(self):
+        if self.checker_list is None:
+            self.checker_list = []
+
         self.model_outs.mkdir(parents=True, exist_ok=True)
         (self.model_outs / "outs.txt").write_text("Lorem Ipsum")
         calculator = self.model.get_calculator(directory=self.model_outs)
+
         atoms = self.get_data()
         atoms = atoms.repeat(self.repeat)
-        if self.optimizer is not None:
-            atoms.calc = calculator
-            optimizer = getattr(ase.optimize, self.optimizer)
+        atoms.calc = calculator
 
-            dyn = optimizer(atoms, trajectory=self.traj.as_posix(), **self.init_kwargs)
-            dyn.run(**self.run_kwargs)
+        atoms_cache = []
+
+        db = znh5md.io.DataWriter(self.traj_file)
+        db.initialize_database_groups()
+
+        optimizer = getattr(ase.optimize, self.optimizer)
+        dyn = optimizer(atoms, **self.init_kwargs)
+
+        for _ in dyn.irun(**self.run_kwargs):
+            stop = []
+            atoms_cache.append(freeze_copy_atoms(atoms))
+            if len(atoms_cache) == self.dump_rate:
+                db.add(
+                    znh5md.io.AtomsReader(
+                        atoms_cache,
+                        frames_per_chunk=self.dump_rate,
+                        step=1,
+                        time=1,
+                    )
+                )
+                atoms_cache = []
+
+            for checker in self.checker_list:
+                stop.append(checker.check(atoms))
+                if stop[-1]:
+                    log.critical(
+                        f"\n {type(checker).__name__} returned false."
+                        "Simulation was stopped."
+                    )
+
+            if any(stop):
+                for checker in self.checker_list:
+                    print(checker.status)
+                break
+
+        db.add(
+            znh5md.io.AtomsReader(
+                atoms_cache,
+                frames_per_chunk=self.dump_rate,
+                step=1,
+                time=1,
+            )
+        )
+
+    def get_atoms(self) -> ase.Atoms:
+        atoms: ase.Atoms = self.get_data()
+        return atoms
 
     @property
-    def atoms(self):
-        with self.state.fs.open(self.traj.as_posix()) as f:
-            return list(ase.io.iread(f))
+    def atoms(self) -> typing.List[ase.Atoms]:
+        return znh5md.ASEH5MD(self.traj_file).get_atoms_list()

--- a/tests/unit_tests/calculators/test_u_ase_geoopt.py
+++ b/tests/unit_tests/calculators/test_u_ase_geoopt.py
@@ -33,8 +33,6 @@ class DebugCheck(base.CheckBase):
 
     def get_desc(self) -> str:
         return str(self)
-    
-
 
 
 def test_ase_geoopt(proj_path, cu_box):
@@ -42,11 +40,10 @@ def test_ase_geoopt(proj_path, cu_box):
     cu_box.rattle(0.5)
     ase.io.write("cu_box.xyz", cu_box)
 
-
-    n_iterations= 5
+    n_iterations = 5
 
     check = DebugCheck(n_iterations=n_iterations)
-    
+
     with ips.Project() as project:
         data = ips.AddData(file="cu_box.xyz")
         model = ips.calculators.EMTSinglePoint(data=data.atoms)
@@ -54,7 +51,7 @@ def test_ase_geoopt(proj_path, cu_box):
             data=data.atoms,
             model=model,
             optimizer="FIRE",
-            checker_list = [check],
+            checker_list=[check],
             run_kwargs={"fmax": 0.05},
         )
 

--- a/tests/unit_tests/calculators/test_u_ase_geoopt.py
+++ b/tests/unit_tests/calculators/test_u_ase_geoopt.py
@@ -1,0 +1,71 @@
+import ase
+import numpy as np
+import zntrack
+
+import ipsuite as ips
+from ipsuite import base
+
+
+class DebugCheck(base.CheckBase):
+    """A check that interupts the dynamics after a fixed amount of iterations.
+    For testing purposes.
+
+    Attributes
+    ----------
+    n_iterations: int
+        number of iterations before stopping
+    """
+
+    n_iterations: int = zntrack.zn.params(10)
+
+    def _post_init_(self) -> None:
+        self.counter = 0
+        self.status = self.__class__.__name__
+
+    def check(self, atoms):
+        if self.counter >= self.n_iterations:
+            return True
+        self.counter += 1
+        return False
+
+    def __str__(self):
+        return self.status
+
+    def get_desc(self) -> str:
+        return str(self)
+    
+
+
+
+def test_ase_geoopt(proj_path, cu_box):
+    cu_box = cu_box[0]
+    cu_box.rattle(0.5)
+    ase.io.write("cu_box.xyz", cu_box)
+
+
+    n_iterations= 5
+
+    check = DebugCheck(n_iterations=n_iterations)
+    
+    with ips.Project() as project:
+        data = ips.AddData(file="cu_box.xyz")
+        model = ips.calculators.EMTSinglePoint(data=data.atoms)
+        opt = ips.calculators.ASEGeoOpt(
+            data=data.atoms,
+            model=model,
+            optimizer="FIRE",
+            checker_list = [check],
+            run_kwargs={"fmax": 0.05},
+        )
+
+    project.run(eager=True)
+
+    assert len(opt.atoms) == n_iterations + 1
+
+    forces = np.linalg.norm(opt.atoms[0].get_forces(), 2, 1)
+    fmax_start = np.max(forces)
+
+    forces = np.linalg.norm(opt.atoms[-1].get_forces(), 2, 1)
+    fmax_end = np.max(forces)
+
+    assert fmax_end < fmax_start


### PR DESCRIPTION
The ASEGeoOpt node awas refactored to use the H5 output format. This unifies its output with that of the other nodes in IPS and also allows one to track uncertanties during an optimization.
Further, it now accepts checks so that geoopt can be interupted e.g. if the uncertainty is too large.
The ThresholdCheck now works for non scalar quantities as well.