### PR TITLE
fix IPS side of TL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
   during the simulation
 - add `pbc: bool` to `Packmol` to fix PBC not supported by PACKMOL
 - add `num_ramp_oscillations: float` to `BoxOscillatingRampModifier`
+- remove `train_log_file` from apax Node

--- a/ipsuite/models/apax.py
+++ b/ipsuite/models/apax.py
@@ -39,8 +39,6 @@ class Apax(MLModel):
         atoms object with the validation data set
     model_directory: pathlib.Path
         model directory
-    train_log_file: pathlib.Path
-        log file directory
     train_data_file: pathlib.Path
         path to the training data
     validation_data_file: pathlib.Path
@@ -52,7 +50,6 @@ class Apax(MLModel):
     model: Optional[MLModel] = zntrack.deps(None)
 
     model_directory: pathlib.Path = dvc.outs(zntrack.nwd / "apax_model")
-    train_log_file: pathlib.Path = dvc.outs(zntrack.nwd / "train.log")
 
     train_data_file: pathlib.Path = dvc.outs(zntrack.nwd / "train_atoms.extxyz")
     validation_data_file: pathlib.Path = dvc.outs(zntrack.nwd / "val_atoms.extxyz")
@@ -104,7 +101,7 @@ class Apax(MLModel):
 
     def train_model(self):
         """Train the model using `apax.train.run`"""
-        apax_run(self._parameter, log_file=self.train_log_file)
+        apax_run(self._parameter)
 
     def move_metrics(self):
         """Move the metrics to the correct directories for DVC"""
@@ -126,9 +123,6 @@ class Apax(MLModel):
         self.train_model()
         self.move_metrics()
         self.get_metrics_from_plots()
-
-        with pathlib.Path(self.train_log_file).open("a") as f:
-            f.write("Training completed\n")
 
     def get_calculator(self, **kwargs):
         """Get an apax ase calculator"""

--- a/ipsuite/models/apax.py
+++ b/ipsuite/models/apax.py
@@ -92,10 +92,12 @@ class Apax(MLModel):
         }
 
         if self.model is not None:
-            param_files = self.model._parameter["data"]["model_path"]
-            base_path = {"base_model_checkpoint": param_files + "/best"}
-
-            self._parameter["checkpoints"].update(base_path)
+            param_files = self.model._parameter["data"]["directory"]
+            base_path = {"base_model_checkpoint": param_files}
+            try:
+                self._parameter["checkpoints"].update(base_path)
+            except KeyError:
+                self._parameter["checkpoints"] = base_path
 
         check_duplicate_keys(custom_parameters, self._parameter["data"], log)
         self._parameter["data"].update(custom_parameters)

--- a/poetry.lock
+++ b/poetry.lock
@@ -259,7 +259,7 @@ znh5md = "^0.1.7"
 type = "git"
 url = "https://github.com/apax-hub/apax.git"
 reference = "dev"
-resolved_reference = "dea322f77afa1ca36761c1ef79fa21107a67c8eb"
+resolved_reference = "39a9f8cf53ed8ce171bf4b6733e73be7aec3ad9b"
 
 [[package]]
 name = "appdirs"


### PR DESCRIPTION
Fix issue with wrong parameters set in apax TL.

Requires: `checkpoints.py 125: model_version_path = Path(model_version_path)`  on apax

# TODO 
- [ ] update apax dev version, once completly fixed there
- [ ] tests (can we test, that the model is truely transfer-learned and not just loaded?)