### PR TITLE
Box oscillating ramp modifier ramp

### DIFF
--- a/ipsuite/calculators/ase_md.py
+++ b/ipsuite/calculators/ase_md.py
@@ -86,7 +86,13 @@ class BoxOscillatingRampModifier(base.IPSNode):
                 )
 
         percentage = step / (total_steps - 1)
-        ramp = percentage * (self.end_cell - self._initial_cell)
+        # we only want the positive part of the sine
+        # we increase the box size to the end cell after the first oscillation
+        percentage_per_oscillation = percentage * self.num_oscillations * 2
+        if percentage_per_oscillation > 1:
+            percentage_per_oscillation = 1
+
+        ramp = percentage_per_oscillation * (self.end_cell - self._initial_cell)
         oscillation = self.cell_amplitude * np.sin(
             2 * np.pi * percentage * self.num_oscillations
         )

--- a/ipsuite/calculators/ase_md.py
+++ b/ipsuite/calculators/ase_md.py
@@ -59,11 +59,15 @@ class BoxOscillatingRampModifier(base.IPSNode):
         number of oscillations. No oscillations will occur if set to 0.
     interval: int, default 1
         interval in which the box size is changed.
+    num_ramp_oscillations: float, default = 0.5
+        number of oscillations to ramp the box size to the end cell.
+        This value has to be smaller than num_oscillations.
     """
 
     end_cell: int = zntrack.zn.params(None)
     cell_amplitude: typing.Union[float, list[float]] = zntrack.zn.params()
     num_oscillations: float = zntrack.zn.params()
+    num_ramp_oscillations: float = zntrack.zn.params(None)
     interval: int = zntrack.zn.params(1)
     _initial_cell = None
 
@@ -88,9 +92,10 @@ class BoxOscillatingRampModifier(base.IPSNode):
         percentage = step / (total_steps - 1)
         # we only want the positive part of the sine
         # we increase the box size to the end cell after the first oscillation
-        percentage_per_oscillation = percentage * self.num_oscillations * 2
-        if percentage_per_oscillation > 1:
-            percentage_per_oscillation = 1
+        percentage_per_oscillation = (
+            percentage * self.num_oscillations / self.num_ramp_oscillations
+        )
+        percentage_per_oscillation = min(percentage_per_oscillation, 1)
 
         ramp = percentage_per_oscillation * (self.end_cell - self._initial_cell)
         oscillation = self.cell_amplitude * np.sin(

--- a/ipsuite/configuration_generation/packmol.py
+++ b/ipsuite/configuration_generation/packmol.py
@@ -63,6 +63,9 @@ class Packmol(base.IPSNode):
 
         if self.density is not None:
             self._get_box_from_molar_volume()
+
+        scaled_box = [x - self.tolerance for x in self.box]
+
         file = f"""
         tolerance {self.tolerance}
         filetype xyz
@@ -72,7 +75,7 @@ class Packmol(base.IPSNode):
             file += f"""
             structure {idx}.xyz
                 number {count}
-                inside box 0 0 0 {" ".join([f"{x:.4f}" for x in self.box])}
+                inside box 0 0 0 {" ".join([f"{x:.4f}" for x in scaled_box])}
             end structure
             """
         with pathlib.Path(self.structures / "packmole.inp").open("w") as f:


### PR DESCRIPTION
Assuming the first ramp in an LotF cycle ends like this:
![image](https://github.com/zincware/IPSuite/assets/46721498/905daa9b-5488-46d0-bfd0-943a5ea9cf12)
the following ramps would go to even smaller boxes than the initial cell and only oscillate as expected during the last oscillation.
With this PR, the targeted `end_cell` is already reached after the first half oscillation
![image](https://github.com/zincware/IPSuite/assets/46721498/870f27e7-9870-409c-92c5-36f192449948)
 