### PR TITLE
TorchD3 with NL reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 - add `num_ramp_oscillations: float` to `BoxOscillatingRampModifier`
 - remove `train_log_file` from apax Node
 - add `density` to `RescaleBoxModifier`
+- add `TorchD3NL` calculator

--- a/ipsuite/calculators/torch_d3.py
+++ b/ipsuite/calculators/torch_d3.py
@@ -8,9 +8,103 @@ import zntrack
 from ase.calculators.calculator import PropertyNotImplementedError
 from ase.calculators.singlepoint import SinglePointCalculator
 from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
+from torch import Tensor
+from ase.units import Bohr
+from ase import Atoms
+from ase.calculators.calculator import Calculator
+from torch_dftd.functions.edge_extraction import calc_edge_index
+from typing import Optional, Tuple, Dict
+
 
 from ipsuite import base, fields
 from ipsuite.utils.ase_sim import freeze_copy_atoms
+
+
+class TorchDFTD3CalculatorNL(TorchDFTD3Calculator):
+    def __init__(
+        self,
+        dft: Optional[Calculator] = None,
+        atoms: Atoms = None,
+        damping: str = "zero",
+        xc: str = "pbe",
+        old: bool = False,
+        device: str = "cpu",
+        cutoff: float = 95.0 * Bohr,
+        cnthr: float = 40.0 * Bohr,
+        abc: bool = False,
+        # --- torch dftd3 specific params ---
+        dtype: torch.dtype = torch.float32,
+        bidirectional: bool = True,
+        cutoff_smoothing: str = "none",
+        skin=0.5,
+        **kwargs,
+    ):
+        
+        self.skin = skin
+        self.pbc = torch.tensor([False, False, False], device=device)
+        self.Z = None
+        self.pos0 = None
+        self.edge_index = None
+        self.S = None
+        super().__init__(
+            dft=dft,
+            atoms=atoms,
+            damping=damping,
+            xc=xc,
+            old=old,
+            device=device,
+            cutoff=cutoff,
+            cnthr=cnthr,
+            abc=abc,
+            dtype=dtype,
+            bidirectional=bidirectional,
+            cutoff_smoothing=cutoff_smoothing,
+            **kwargs
+        )
+
+    def _calc_edge_index(
+        self,
+        pos: Tensor,
+        cell: Optional[Tensor] = None,
+        pbc: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        return calc_edge_index(
+            pos, cell, pbc, cutoff=self.cutoff + self.skin, bidirectional=self.bidirectional
+        )
+
+    def _preprocess_atoms(self, atoms: Atoms) -> Dict[str, Optional[Tensor]]:
+        pos = torch.tensor(atoms.get_positions(), device=self.device, dtype=self.dtype)
+        Z = torch.tensor(atoms.get_atomic_numbers(), device=self.device)
+
+        if self.pos0 is None:
+            self.pos0 = torch.zeros_like(pos)
+        if self.Z is None:
+            self.Z = Z.clone()
+
+        if any(atoms.pbc):
+            cell: Optional[Tensor] = torch.tensor(
+                atoms.get_cell(), device=self.device, dtype=self.dtype
+            )
+        else:
+            cell = None
+        pbc = torch.tensor(atoms.pbc, device=self.device)
+        condition = (torch.any(self.pbc != pbc) or len(self.Z) != len(Z) or
+                ((self.pos0 - pos)**2).sum(1).max() > self.skin**2 / 4.0)
+
+        if condition:
+            self.edge_index, self.S = self._calc_edge_index(pos, cell, pbc)
+            self.pos0 = pos
+            self.pbc = pbc
+
+        if cell is None:
+            shift_pos = self.S
+        else:
+            shift_pos = torch.mm(self.S, cell.detach())
+
+        input_dicts = dict(
+            pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=self.edge_index, shift_pos=shift_pos
+        )
+        return input_dicts
 
 
 class TorchD3(base.ProcessAtoms):
@@ -29,6 +123,9 @@ class TorchD3(base.ProcessAtoms):
         Data type used for the calculation.
     device : str
         Device used for the calculation. Defaults to "cuda" if available, otherwise "cpu".
+    skin : float
+        If > 0, switches to a D3 implementation that reuses neighborlists.
+        This can significantly improve performance.
     """
 
     xc: str = zntrack.params()
@@ -38,6 +135,7 @@ class TorchD3(base.ProcessAtoms):
     cnthr: float = zntrack.params()
     dtype: str = zntrack.params()
     device: str = zntrack.meta.Text(None)
+    skin: float = zntrack.params(0.0)
 
     atoms: list[ase.Atoms] = fields.Atoms()
 
@@ -84,14 +182,29 @@ class TorchD3(base.ProcessAtoms):
             dtype = torch.float32
         else:
             raise ValueError("dtype must be float64 or float32")
+        
+        if self.skin < 1e-5:
+            calc = TorchDFTD3Calculator(
+                xc=self.xc,
+                damping=self.damping,
+                cutoff=self.cutoff,
+                abc=self.abc,
+                cnthr=self.cnthr,
+                dtype=dtype,
+                atoms=None,
+                device=self.device,
+            )
+        else:
+            calc = TorchDFTD3CalculatorNL(
+                xc=self.xc,
+                damping=self.damping,
+                cutoff=self.cutoff,
+                abc=self.abc,
+                cnthr=self.cnthr,
+                dtype=dtype,
+                atoms=None,
+                device=self.device,
+                skin=self.skin,
+            )
 
-        return TorchDFTD3Calculator(
-            xc=self.xc,
-            damping=self.damping,
-            cutoff=self.cutoff,
-            abc=self.abc,
-            cnthr=self.cnthr,
-            dtype=dtype,
-            atoms=None,
-            device=self.device,
-        )
+        return calc

--- a/tests/integration/calculators/test_torchd3.py
+++ b/tests/integration/calculators/test_torchd3.py
@@ -21,6 +21,7 @@ def test_d3(proj_path):
             abc=False,
             cnthr=4,
             dtype="float32",
+            device="cpu",
         )
 
     proj.run()
@@ -55,15 +56,32 @@ def test_d3_existing_calc(proj_path):
             abc=False,
             cnthr=4,
             dtype="float32",
+            device="cpu",
+        )
+        d3nl = ips.calculators.TorchD3(
+            data=lj.atoms,
+            xc="pbe",
+            damping="bj",
+            cutoff=5,
+            abc=False,
+            cnthr=4,
+            dtype="float32",
+            device="cpu",
+            skin=0.5,
+            name="d3nl"
         )
 
     proj.run()
 
     lj.load()
     d3.load()
+    d3nl.load()
 
     assert lj.atoms[0].get_potential_energy() == pytest.approx(1.772068860)
     assert lj.atoms[0].get_potential_energy() - d3.atoms[
+        0
+    ].get_potential_energy() == pytest.approx(0.00978192157)
+    assert lj.atoms[0].get_potential_energy() - d3nl.atoms[
         0
     ].get_potential_energy() == pytest.approx(0.00978192157)
 


### PR DESCRIPTION
I have added a TorchD3 calculator which accepts a neighborlist skin parameter, thereby allowing NL reuse and quite significant speedups.
only 2 methods from the base class are overwritten and the actual changes are about 10 lines of code.