### PR TITLE
Data id in atoms

### DIFF
--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -35,7 +35,7 @@ class ProcessAtoms(IPSNode):
     """
 
     data: list[ase.Atoms] = zntrack.deps()
-    data_file: str = zntrack.dvc.deps(None)
+    data_file: str = zntrack.deps_path(None)
     data_id: typing.Optional[int] = None  # zntrack.params(None)
     atoms: list[ase.Atoms] = fields.Atoms()
 
@@ -94,8 +94,8 @@ class ProcessSingleAtom(IPSNode):
     """
 
     data: typing.Union[ase.Atoms, typing.List[ase.Atoms]] = zntrack.deps()
-    data_file: str = zntrack.dvc.deps(None)
-    data_id: typing.Optional[int] = zntrack.zn.params(0)
+    data_file: str = zntrack.deps_path(None)
+    data_id: typing.Optional[int] = zntrack.params(0)
 
     atoms: typing.List[ase.Atoms] = fields.Atoms()
 
@@ -172,8 +172,8 @@ class Mapping(ProcessAtoms):
         The indices of the molecules will be frozen for all configurations.
     """
 
-    molecules: list[ase.Atoms] = zntrack.zn.outs()
-    frozen: bool = zntrack.zn.params(False)
+    molecules: list[ase.Atoms] = zntrack.outs()
+    frozen: bool = zntrack.params(False)
 
     # TODO, should we allow to transfer the frozen mapping to another node?
     #  mapping = Mapping(frozen=True, reference=mapping)

--- a/ipsuite/base/base.py
+++ b/ipsuite/base/base.py
@@ -36,6 +36,7 @@ class ProcessAtoms(IPSNode):
 
     data: list[ase.Atoms] = zntrack.deps()
     data_file: str = zntrack.dvc.deps(None)
+    data_id: typing.Optional[int] = None  # zntrack.params(None)
     atoms: list[ase.Atoms] = fields.Atoms()
 
     def _post_init_(self):
@@ -50,16 +51,21 @@ class ProcessAtoms(IPSNode):
     def get_data(self) -> list[ase.Atoms]:
         """Get the atoms data to process."""
         if self.data is not None:
-            return self.data
+            data = self.data
         elif self.data_file is not None:
             try:
                 with self.state.fs.open(pathlib.Path(self.data_file).as_posix()) as f:
-                    return list(ase.io.iread(f))
+                    data = list(ase.io.iread(f))
             except FileNotFoundError:
                 # File can not be opened with DVCFileSystem, try normal open
-                return list(ase.io.iread(self.data_file))
+                data = list(ase.io.iread(self.data_file))
         else:
             raise ValueError("No data given.")
+
+        if self.data_id is not None:
+            return [data[self.data_id]]
+        else:
+            return data
 
 
 class ProcessSingleAtom(IPSNode):
@@ -134,10 +140,16 @@ class AnalyseProcessAtoms(IPSNode):
     """Analyse the output of a ProcessAtoms Node."""
 
     data: ProcessAtoms = zntrack.deps()
+    reference: ProcessAtoms = zntrack.deps(None)
 
     def get_data(self) -> typing.Tuple[list[ase.Atoms], list[ase.Atoms]]:
-        self.data.update_data()  # otherwise, data might not be available
-        return self.data.data, self.data.atoms
+
+        if self.reference is None:
+            self.data.update_data()  # otherwise, data might not be available
+            return self.data.data, self.data.atoms
+        else:
+            # TODO: support both, Nodes and Connections
+            return self.reference, self.data
 
 
 class Mapping(ProcessAtoms):


### PR DESCRIPTION
Allow the usage of `data_id` in `ProcessAtoms` to restrict the processing to only a single configuration but keep it a list.

E.g. if you need to run DFT, you can use `CP2KSinglePoint` and provide `data_id` which was not possible before.