### PR TITLE
CP2K without PBC

### DIFF
--- a/ipsuite/calculators/cp2k.py
+++ b/ipsuite/calculators/cp2k.py
@@ -192,6 +192,7 @@ class CP2KSinglePoint(base.ProcessAtoms):
     wfn_restart_node = zntrack.deps(None)
     output_file = zntrack.outs_path(zntrack.nwd / "structures.h5")
     cp2k_directory = zntrack.outs_path(zntrack.nwd / "cp2k")
+    compute_stress_tensor: bool = zntrack.params(True)
 
     def run(self):
         """ZnTrack run method.
@@ -283,7 +284,7 @@ class CP2KSinglePoint(base.ProcessAtoms):
             potential_file=None,
             poisson_solver=None,
             pseudo_potential=None,
-            stress_tensor=True,
+            stress_tensor=self.compute_stress_tensor,
             xc=None,
             print_level=None,
             label="cp2k",

--- a/ipsuite/configuration_generation/packmol.py
+++ b/ipsuite/configuration_generation/packmol.py
@@ -93,9 +93,8 @@ class Packmol(base.IPSNode):
         subprocess.check_call("packmol < packmole.inp", shell=True, cwd=self.structures)
 
         atoms = ase.io.read(self.structures / "mixture.xyz")
-        if self.pbc:
-            atoms.cell = self.box
-            atoms.pbc = True
+        atoms.cell = self.box
+        atoms.pbc = self.pbc
         self.atoms = [atoms]
 
     def _get_box_from_molar_volume(self):


### PR DESCRIPTION
TODO: add cell vectors to `Smiles2Atoms` but set pbc to false so that the CP2k calculator can work with them - or generate cell vectors in the CP2k calculator.