### PR TITLE
save more data from the GMX run

### DIFF
--- a/ipsuite/configuration_generation/gmx.py
+++ b/ipsuite/configuration_generation/gmx.py
@@ -68,7 +68,8 @@ def timestep_to_atoms(u: mda.Universe, ts: Timestep) -> Atoms:
     forces = forces.magnitude
     energy = 0
     with contextlib.suppress(KeyError):
-        energy = ts.aux["Total Energy"] * ureg.kilocalories / ureg.mol
+        energy = ts.aux["Potential"]
+        energy = energy *  ureg.kilocalories / ureg.mol
         energy.ito(ureg.eV / ureg.particle)
         energy = energy.magnitude
     

--- a/ipsuite/configuration_generation/gmx.py
+++ b/ipsuite/configuration_generation/gmx.py
@@ -69,7 +69,7 @@ def timestep_to_atoms(u: mda.Universe, ts: Timestep) -> Atoms:
     energy = 0
     with contextlib.suppress(KeyError):
         energy = ts.aux["Potential"]
-        energy = energy *  ureg.kilocalories / ureg.mol
+        energy = energy * ureg.kilocalories / ureg.mol
         energy.ito(ureg.eV / ureg.particle)
         energy = energy.magnitude
 

--- a/ipsuite/configuration_generation/gmx.py
+++ b/ipsuite/configuration_generation/gmx.py
@@ -71,10 +71,17 @@ def timestep_to_atoms(u: mda.Universe, ts: Timestep) -> Atoms:
         energy = ts.aux["Total Energy"] * ureg.kilocalories / ureg.mol
         energy.ito(ureg.eV / ureg.particle)
         energy = energy.magnitude
-
+    
     atoms = Atoms(symbols, positions=positions, cell=cell, pbc=True)
     atoms.calc = SinglePointCalculator(atoms, energy=energy, forces=forces)
     atoms.info["h5md_time"] = (ts.time * ureg.picosecond).to(ureg.femtosecond).magnitude
+
+    with contextlib.suppress(KeyError):
+        atoms.info["temperature"] = ts.aux["Temperature"]
+    with contextlib.suppress(KeyError):
+        atoms.info["pressure"] = ts.aux["Pressure"]
+    with contextlib.suppress(KeyError):
+        atoms.info["density"] = ts.aux["Density"]
 
     return atoms
 


### PR DESCRIPTION
Available keys are:
```
['Time', 'Bond', 'Angle', 'Proper Dih.', 'Fourier Dih.', 'Per. Imp. Dih.', 'LJ-14', 'Coulomb-14', 'LJ (SR)', 'Disper. corr.', 'Coulomb (SR)', 'Coul. recip.', 'Potential', 'Kinetic En.', 'Total Energy', 'Conserved En.', 'Temperature', 'Pres. DC', 'Pressure', 'Box-X', 'Box-Y', 'Box-Z', 'Volume', 'Density', 'pV', 'Enthalpy', 'Vir-XX', 'Vir-XY', 'Vir-XZ', 'Vir-YX', 'Vir-YY', 'Vir-YZ', 'Vir-ZX', 'Vir-ZY', 'Vir-ZZ', 'Pres-XX', 'Pres-XY', 'Pres-XZ', 'Pres-YX', 'Pres-YY', 'Pres-YZ', 'Pres-ZX', 'Pres-ZY', 'Pres-ZZ', '#Surf*SurfTen', 'T-System']
```