### PR TITLE
allow lazy loading directly from the ipsuite package root

### DIFF
--- a/ipsuite/__init__.py
+++ b/ipsuite/__init__.py
@@ -2,48 +2,13 @@
 
 import importlib.metadata
 
-from ipsuite import (
-    analysis,
-    base,
-    bootstrap,
-    calculators,
-    configuration_comparison,
-    configuration_generation,
-    configuration_selection,
-    data_loading,
-    datasets,
-    fields,
-    geometry,
-    models,
-    nodes,
-    utils,
-)
-from ipsuite.data_loading.add_data_ase import AddData
-from ipsuite.project import Project
-from ipsuite.utils import combine
 from ipsuite.utils.logs import setup_logging
+from ipsuite.utils.helpers import setup_ase
 
-__all__ = [
-    "base",
-    "bootstrap",
-    "utils",
-    "AddData",
-    "Project",
-    "configuration_comparison",
-    "configuration_selection",
-    "configuration_generation",
-    "models",
-    "analysis",
-    "fields",
-    "calculators",
-    "geometry",
-    "combine",
-    "data_loading",
-    "datasets",
-    "nodes",
-]
+import lazy_loader as lazy
+
+__getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
 
 __version__ = importlib.metadata.version(__name__)
 setup_logging(__name__)
-
-utils.helpers.setup_ase()
+setup_ase()

--- a/ipsuite/__init__.py
+++ b/ipsuite/__init__.py
@@ -2,10 +2,10 @@
 
 import importlib.metadata
 
-from ipsuite.utils.logs import setup_logging
-from ipsuite.utils.helpers import setup_ase
-
 import lazy_loader as lazy
+
+from ipsuite.utils.helpers import setup_ase
+from ipsuite.utils.logs import setup_logging
 
 __getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
 

--- a/ipsuite/__init__.pyi
+++ b/ipsuite/__init__.pyi
@@ -1,0 +1,105 @@
+# Models
+from  .models import GAP
+from  .models import EnsembleModel
+from  .models import MACE
+from  .models import Nequip
+from  .models import Apax
+from  .models import ApaxEnsemble
+
+# Configuration Selection
+from  .configuration_selection import IndexSelection
+from  .configuration_selection import KernelSelection
+from  .configuration_selection import RandomSelection
+from  .configuration_selection import SplitSelection
+from  .configuration_selection import UniformArangeSelection
+from  .configuration_selection import UniformEnergeticSelection
+from  .configuration_selection import UniformTemporalSelection
+from  .configuration_selection import ThresholdSelection
+from  .configuration_selection import FilterOutlier
+from  .models.apax import BatchKernelSelection
+
+# Configuration Comparison
+from  .configuration_comparison import REMatch
+from  .configuration_comparison import MMKernel
+
+# Configuration Generation
+from  .configuration_generation import Packmol
+from  .configuration_generation import MultiPackmol
+from  .configuration_generation import SmilesToAtoms
+from  .configuration_generation import SmilesToConformers
+from  .configuration_generation import Smiles2Gromacs
+
+# Data
+from  .data_loading import AddData
+from  .data_loading import AddDataH5MD
+from  .data_loading import ReadData
+
+# Datasets
+from  .datasets import MD22Dataset
+
+# Bootstrap
+from  .bootstrap import RattleAtoms
+from  .bootstrap import TranslateMolecules
+from  .bootstrap import RotateMolecules
+from  .bootstrap import SurfaceRasterScan
+from  .bootstrap import SurfaceRasterMetrics
+
+# Analysis
+from  .analysis import DipoleHistogram
+from  .analysis import EnergyHistogram
+from  .analysis import ForcesHistogram
+from  .analysis import StressHistogram
+from  .analysis import ForcesUncertaintyHistogram
+from  .analysis import EnergyUncertaintyHistogram
+from  .analysis import ModelEnsembleAnalysis
+from  .analysis import PredictionMetrics
+from  .analysis import ForceAngles
+from  .analysis import RattleAnalysis
+from  .analysis import Prediction
+from  .analysis import CalibrationMetrics
+from  .analysis import BoxScale
+from  .analysis import BoxHeatUp
+from  .analysis import NaNCheck
+from  .analysis import ConnectivityCheck
+from  .analysis import EnergySpikeCheck
+from  .analysis import MDStability
+from  .analysis import MoveSingleParticle
+from  .analysis import AnalyseGlobalForceSensitivity
+from  .analysis import AnalyseSingleForceSensitivity
+from  .analysis import ForceDecomposition
+from  .analysis import ThresholdCheck
+from  .analysis import TemperatureCheck
+from  .calculators import FixedSphereConstraint
+from  .calculators import FixedLayerConstraint
+from  .analysis import AnalyseDensity
+
+# Calculators
+from  .calculators import CP2KSinglePoint
+from  .calculators import CP2KYaml
+from  .calculators import ASEGeoOpt
+from  .calculators import ASEMD
+from  .calculators import xTBSinglePoint
+from  .calculators import LJSinglePoint
+from  .calculators import EMTSinglePoint
+from  .calculators import OrcaSinglePoint
+from  .calculators import ApaxJaxMD
+from  .calculators import LammpsSimulator
+from  .calculators import MixCalculator
+from  .calculators import LangevinThermostat
+from  .calculators import VelocityVerletDynamic
+from  .calculators import NPTThermostat
+from  .calculators import RescaleBoxModifier
+from  .calculators import BoxOscillatingRampModifier
+from  .calculators import TemperatureRampModifier
+from  .calculators import TemperatureOscillatingRampModifier
+from  .calculators import TemperatureRampModifier
+from  .calculators import TorchD3
+
+# Geometry
+from  .geometry import BarycenterMapping
+
+# Data manipulation
+from  .base import Flatten
+
+# Others
+from .project import Project

--- a/ipsuite/__init__.pyi
+++ b/ipsuite/__init__.pyi
@@ -1,105 +1,22 @@
 # Models
-from  .models import GAP
-from  .models import EnsembleModel
-from  .models import MACE
-from  .models import Nequip
-from  .models import Apax
-from  .models import ApaxEnsemble
-
-# Configuration Selection
-from  .configuration_selection import IndexSelection
-from  .configuration_selection import KernelSelection
-from  .configuration_selection import RandomSelection
-from  .configuration_selection import SplitSelection
-from  .configuration_selection import UniformArangeSelection
-from  .configuration_selection import UniformEnergeticSelection
-from  .configuration_selection import UniformTemporalSelection
-from  .configuration_selection import ThresholdSelection
-from  .configuration_selection import FilterOutlier
-from  .models.apax import BatchKernelSelection
-
-# Configuration Comparison
-from  .configuration_comparison import REMatch
-from  .configuration_comparison import MMKernel
-
-# Configuration Generation
-from  .configuration_generation import Packmol
-from  .configuration_generation import MultiPackmol
-from  .configuration_generation import SmilesToAtoms
-from  .configuration_generation import SmilesToConformers
-from  .configuration_generation import Smiles2Gromacs
-
-# Data
-from  .data_loading import AddData
-from  .data_loading import AddDataH5MD
-from  .data_loading import ReadData
-
-# Datasets
-from  .datasets import MD22Dataset
-
-# Bootstrap
-from  .bootstrap import RattleAtoms
-from  .bootstrap import TranslateMolecules
-from  .bootstrap import RotateMolecules
-from  .bootstrap import SurfaceRasterScan
-from  .bootstrap import SurfaceRasterMetrics
-
 # Analysis
-from  .analysis import DipoleHistogram
-from  .analysis import EnergyHistogram
-from  .analysis import ForcesHistogram
-from  .analysis import StressHistogram
-from  .analysis import ForcesUncertaintyHistogram
-from  .analysis import EnergyUncertaintyHistogram
-from  .analysis import ModelEnsembleAnalysis
-from  .analysis import PredictionMetrics
-from  .analysis import ForceAngles
-from  .analysis import RattleAnalysis
-from  .analysis import Prediction
-from  .analysis import CalibrationMetrics
-from  .analysis import BoxScale
-from  .analysis import BoxHeatUp
-from  .analysis import NaNCheck
-from  .analysis import ConnectivityCheck
-from  .analysis import EnergySpikeCheck
-from  .analysis import MDStability
-from  .analysis import MoveSingleParticle
-from  .analysis import AnalyseGlobalForceSensitivity
-from  .analysis import AnalyseSingleForceSensitivity
-from  .analysis import ForceDecomposition
-from  .analysis import ThresholdCheck
-from  .analysis import TemperatureCheck
-from  .calculators import FixedSphereConstraint
-from  .calculators import FixedLayerConstraint
-from  .analysis import AnalyseDensity
-
-# Calculators
-from  .calculators import CP2KSinglePoint
-from  .calculators import CP2KYaml
-from  .calculators import ASEGeoOpt
-from  .calculators import ASEMD
-from  .calculators import xTBSinglePoint
-from  .calculators import LJSinglePoint
-from  .calculators import EMTSinglePoint
-from  .calculators import OrcaSinglePoint
-from  .calculators import ApaxJaxMD
-from  .calculators import LammpsSimulator
-from  .calculators import MixCalculator
-from  .calculators import LangevinThermostat
-from  .calculators import VelocityVerletDynamic
-from  .calculators import NPTThermostat
-from  .calculators import RescaleBoxModifier
-from  .calculators import BoxOscillatingRampModifier
-from  .calculators import TemperatureRampModifier
-from  .calculators import TemperatureOscillatingRampModifier
-from  .calculators import TemperatureRampModifier
-from  .calculators import TorchD3
-
-# Geometry
-from  .geometry import BarycenterMapping
 
 # Data manipulation
-from  .base import Flatten
+
+# Bootstrap
+
+# Calculators
+
+# Configuration Comparison
+
+# Configuration Generation
+
+# Configuration Selection
+
+# Data
+
+# Datasets
+
+# Geometry
 
 # Others
-from .project import Project


### PR DESCRIPTION
Do we want to keep `ips.nodes`? If not, all existing workflows will be broken or we need to setup a fix.