### PR TITLE
fix ase md failing for bad models

### DIFF
--- a/ipsuite/calculators/ase_md.py
+++ b/ipsuite/calculators/ase_md.py
@@ -730,7 +730,7 @@ class ASEMD(base.IPSNode):
                     current_step += 1
 
         if not self.pop_last and self.steps_before_stopping != -1:
-            metrics_dict = update_metrics_dict(atoms, metrics_dict, self.checks)
+            metrics_dict = update_metrics_dict(atoms, metrics_dict, self.checks, current_step)
             atoms_cache.append(freeze_copy_atoms(atoms))
             current_step += 1
 

--- a/ipsuite/calculators/ase_md.py
+++ b/ipsuite/calculators/ase_md.py
@@ -730,7 +730,9 @@ class ASEMD(base.IPSNode):
                     current_step += 1
 
         if not self.pop_last and self.steps_before_stopping != -1:
-            metrics_dict = update_metrics_dict(atoms, metrics_dict, self.checks, current_step)
+            metrics_dict = update_metrics_dict(
+                atoms, metrics_dict, self.checks, current_step
+            )
             atoms_cache.append(freeze_copy_atoms(atoms))
             current_step += 1
 


### PR DESCRIPTION
if a simulation fails immediately due to a check, the node would fail as the steps list in the metrics dict is empty