### PR TITLE
recreate calc

### DIFF
--- a/ipsuite/calculators/cp2k.py
+++ b/ipsuite/calculators/cp2k.py
@@ -105,6 +105,9 @@ class CP2KSinglePoint(base.IPSNode):
                     raise err
                 log.warning(f"Skipping calculation: {err}")
                 self.failed_configs["skipped"].append(idx)
+                # remove restart files after non-converged runs
+                for file in self.cp2k_directory.glob("*wfn"):
+                    file.unlink()
                 calc = self.get_calculator()
                 continue
 

--- a/ipsuite/calculators/cp2k.py
+++ b/ipsuite/calculators/cp2k.py
@@ -105,6 +105,7 @@ class CP2KSinglePoint(base.IPSNode):
                     raise err
                 log.warning(f"Skipping calculation: {err}")
                 self.failed_configs["skipped"].append(idx)
+                calc = self.get_calculator()
                 continue
 
         for file in self.cp2k_directory.glob("cp2k-RESTART.wfn.*"):


### PR DESCRIPTION
removing the restart wfn on failure to
- avoid corrupted restart files (I've seen this resulting in a fortran error)
- avoid starting from a really bad restart