### PR TITLE
switched xtb-python with tblite

### DIFF
--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -12,6 +12,9 @@ log = logging.getLogger(__name__)
 class xTBSinglePoint(base.ProcessAtoms):
     """Node for labeling date with xTB and obtaining ASE calculators.
 
+    Installation:
+    conda install conda-forge::tblite-python
+
     Attributes
     ----------
     method: str
@@ -19,6 +22,14 @@ class xTBSinglePoint(base.ProcessAtoms):
     """
 
     method: str = zntrack.params("GFN1-xTB")
+    charge: int = zntrack.params(None)
+    multiplicity: int = zntrack.params(None)
+    accuracy: float = zntrack.params(1.0)
+    electronic_temperature: float = zntrack.params(300.0)
+    max_iterations: int = zntrack.params(250)
+    initial_guess: str = zntrack.params("sad")
+    mixer_damping: float = zntrack.params(0.4)
+    spin_polarization: float = zntrack.params(None)
 
     def run(self):
         self.frames = []
@@ -33,11 +44,23 @@ class xTBSinglePoint(base.ProcessAtoms):
     def get_calculator(self, **kwargs):
         """Get an xtb ase calculator."""
         try:
-            from xtb.ase.calculator import XTB
+            from tblite.ase import TBLite
         except ImportError:
             log.warning(
                 "No xtb-python installation found. install via `conda install xtb-python`"
             )
             raise
 
-        return XTB(method=self.method)
+
+        calc = TBLite(
+            method=self.method,
+            charge=self.charge,
+            multiplicity=self.multiplicity,
+            accuracy=self.accuracy,
+            electronic_temperature=self.electronic_temperature,
+            max_iterations=self.max_iterations,
+            initial_guess=self.initial_guess,
+            mixer_damping=self.mixer_damping,
+            spin_polarization=self.spin_polarization,
+        )
+        return calc

--- a/ipsuite/calculators/xtb.py
+++ b/ipsuite/calculators/xtb.py
@@ -51,7 +51,6 @@ class xTBSinglePoint(base.ProcessAtoms):
             )
             raise
 
-
         calc = TBLite(
             method=self.method,
             charge=self.charge,


### PR DESCRIPTION
xtb-python is deprecated. tblite is more feature rich, importantly, the gfn2-xtb implementation is compatible with pbc.