### PR TITLE
Update apply.py

### DIFF
--- a/ipsuite/calc/apply.py
+++ b/ipsuite/calc/apply.py
@@ -54,7 +54,7 @@ class ApplyCalculator(zntrack.Node):
 
     data: list[ase.Atoms] = zntrack.deps()
     model: NodeWithCalculator = zntrack.deps()
-    dump_rate: int | None = zntrack.params(None)
+    dump_rate: int | None = zntrack.params(1)
 
     frames_path: pathlib.Path = zntrack.outs_path(zntrack.nwd / "frames.h5")
     model_outs: pathlib.Path = zntrack.outs_path(zntrack.nwd / "model")


### PR DESCRIPTION
change default to 1, as this is mostly used with e.g. DFT and missing out there is more annoying than slow MLIP labeling.